### PR TITLE
Make clearer in README how sudoers file should be modified.

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -123,7 +123,7 @@ nano /home/deploy/.ssh/authorized_keys
 chmod 400 /home/deploy/.ssh/authorized_keys
 chown deploy:deploy /home/deploy -R
 
-This account should be set up for passwordless sudo. Use @visudo@ and add this line:
+This account should be set up for passwordless sudo. Use @visudo@ and add this line to the bottom (later lines have precedence):
 
 bc. deploy  ALL=(ALL) NOPASSWD: ALL
 


### PR DESCRIPTION
Adding the suggested line in the wrong place will cause you to
be locked out after initial deployment.

Arguably you should know what you're doing with these things,
but for those who don't have deep background in sys admin this
can be an unexpected gotcha (Ansible pre 1.7 does not error).