### PR TITLE
Update roundcube role to use wheezy backports

### DIFF
--- a/roles/webmail/files/etc_roundcube_main.inc.php
+++ b/roles/webmail/files/etc_roundcube_main.inc.php
@@ -6,7 +6,10 @@
 |                                                                       |
 | This file is part of the Roundcube Webmail client                     |
 | Copyright (C) 2005-2011, The Roundcube Dev Team                       |
-| Licensed under the GNU GPL                                            |
+|                                                                       |
+| Licensed under the GNU General Public License version 3 or            |
+| any later version with exceptions for skins & plugins.                |
+| See the README file for a full license statement.                     |
 |                                                                       |
 +-----------------------------------------------------------------------+
 
@@ -18,14 +21,14 @@ $rcmail_config = array();
 // LOGGING/DEBUGGING
 // ----------------------------------
 
-// system error reporting: 1 = log; 2 = report (not implemented yet), 4 = show, 8 = trace
+// system error reporting, sum of: 1 = log; 4 = show, 8 = trace
 $rcmail_config['debug_level'] = 1;
 
 // log driver:  'syslog' or 'file'.
 $rcmail_config['log_driver'] = 'file';
 
 // date format for log entries
-// (read http://php.net/manual/en/function.date.php for all format characters)
+// (read http://php.net/manual/en/function.date.php for all format characters)  
 $rcmail_config['log_date_format'] = 'd-M-Y H:i:s O';
 
 // Syslog ident string to use, if using the 'syslog' log driver.
@@ -60,22 +63,24 @@ $rcmail_config['smtp_debug'] = false;
 // IMAP
 // ----------------------------------
 
-// the mail host chosen to perform the log-in
-// leave blank to show a textbox at login, give a list of hosts
+// The mail host chosen to perform the log-in.
+// Leave blank to show a textbox at login, give a list of hosts
 // to display a pulldown menu or set one host as string.
 // To use SSL/TLS connection, enter hostname with prefix ssl:// or tls://
 // Supported replacement variables:
-// %n - http hostname ($_SERVER['SERVER_NAME'])
-// %d - domain (http hostname without the first part)
+// %n - hostname ($_SERVER['SERVER_NAME'])
+// %t - hostname without the first part
+// %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
 // %s - domain name after the '@' from e-mail address provided at login screen
-// For example %n = mail.domain.tld, %d = domain.tld
-// $rcmail_config['default_host'] = '';
+// For example %n = mail.domain.tld, %t = domain.tld
+// WARNING: After hostname change update of mail_host column in users table is
+//          required to match old user data records with the new host.
 $rcmail_config['default_host'] = 'ssl://127.0.0.1:993';
 
 // TCP port used for IMAP connections
-// $rcmail_config['default_port'] = 143;
+$rcmail_config['default_port'] = 143;
 
-// IMAP AUTH type (DIGEST-MD5, CRAM-MD5, LOGIN, PLAIN or empty to use
+// IMAP AUTH type (DIGEST-MD5, CRAM-MD5, LOGIN, PLAIN or null to use
 // best server supported one)
 $rcmail_config['imap_auth_type'] = null;
 
@@ -104,6 +109,10 @@ $rcmail_config['imap_force_caps'] = false;
 // Enable this option to force LSUB command usage instead.
 $rcmail_config['imap_force_lsub'] = false;
 
+// Some server configurations (e.g. Courier) doesn't list folders in all namespaces
+// Enable this option to force listing of folders in all namespaces
+$rcmail_config['imap_force_ns'] = false;
+
 // IMAP connection timeout, in seconds. Default: 0 (no limit)
 $rcmail_config['imap_timeout'] = 0;
 
@@ -129,24 +138,23 @@ $rcmail_config['messages_cache'] = false;
 // If left blank, the PHP mail() function is used
 // Supported replacement variables:
 // %h - user's IMAP hostname
-// %n - http hostname ($_SERVER['SERVER_NAME'])
-// %d - domain (http hostname without the first part)
+// %n - hostname ($_SERVER['SERVER_NAME'])
+// %t - hostname without the first part
+// %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
 // %z - IMAP domain (IMAP hostname without the first part)
-// For example %n = mail.domain.tld, %d = domain.tld
-// $rcmail_config['smtp_server'] = '';
+// For example %n = mail.domain.tld, %t = domain.tld
 $rcmail_config['smtp_server'] = 'ssl://127.0.0.1';
 
-// SMTP port (default is 25; 465 for SSL)
+// SMTP port (default is 25; use 587 for STARTTLS or 465 for the
+// deprecated SSL over SMTP (aka SMTPS))
 $rcmail_config['smtp_port'] = 465;
 
 // SMTP username (if required) if you use %u as the username Roundcube
 // will use the current username for login
-//$rcmail_config['smtp_user'] = '';
 $rcmail_config['smtp_user'] = '%u';
 
 // SMTP password (if required) if you use %p as the password Roundcube
 // will use the current user's password for login
-//$rcmail_config['smtp_pass'] = '';
 $rcmail_config['smtp_pass'] = '%p';
 
 // SMTP AUTH type (DIGEST-MD5, CRAM-MD5, LOGIN, PLAIN or empty to use
@@ -159,13 +167,15 @@ $rcmail_config['smtp_auth_cid'] = null;
 // Optional SMTP authentication password to be used for smtp_auth_cid
 $rcmail_config['smtp_auth_pw'] = null;
 
-// SMTP HELO host
-// Hostname to give to the remote server for SMTP 'HELO' or 'EHLO' messages
-// Leave this blank and you will get the server variable 'server_name' or
-// localhost if that isn't defined.
+// SMTP HELO host 
+// Hostname to give to the remote server for SMTP 'HELO' or 'EHLO' messages 
+// Leave this blank and you will get the server variable 'server_name' or 
+// localhost if that isn't defined. 
 $rcmail_config['smtp_helo_host'] = '';
 
 // SMTP connection timeout, in seconds. Default: 0 (no limit)
+// Note: There's a known issue where using ssl connection with
+// timeout > 0 causes connection errors (https://bugs.php.net/bug.php?id=54511)
 $rcmail_config['smtp_timeout'] = 0;
 
 // ----------------------------------
@@ -175,6 +185,25 @@ $rcmail_config['smtp_timeout'] = 0;
 // THIS OPTION WILL ALLOW THE INSTALLER TO RUN AND CAN EXPOSE SENSITIVE CONFIG DATA.
 // ONLY ENABLE IT IF YOU'RE REALLY SURE WHAT YOU'RE DOING!
 $rcmail_config['enable_installer'] = false;
+
+// don't allow these settings to be overriden by the user
+$rcmail_config['dont_override'] = array();
+
+// provide an URL where a user can get support for this Roundcube installation
+// PLEASE DO NOT LINK TO THE ROUNDCUBE.NET WEBSITE HERE!
+$rcmail_config['support_url'] = '';
+
+// replace Roundcube logo with this image
+// specify an URL relative to the document root of this Roundcube installation
+$rcmail_config['skin_logo'] = null;
+
+// automatically create a new Roundcube user when log-in the first time.
+// a new user will be created once the IMAP login succeeds.
+// set to false if only registered users can use this service
+$rcmail_config['auto_create_user'] = true;
+
+// Enables possibility to log in using email address from user identities
+$rcmail_config['user_aliases'] = false;
 
 // use this folder to store log files (must be writeable for apache user)
 // This is used by the 'file' log driver.
@@ -195,39 +224,40 @@ $rcmail_config['force_https'] = true;
 // tell PHP that it should work as under secure connection
 // even if it doesn't recognize it as secure ($_SERVER['HTTPS'] is not set)
 // e.g. when you're running Roundcube behind a https proxy
+// this option is mutually exclusive to 'force_https' and only either one of them should be set to true.
 $rcmail_config['use_https'] = false;
 
 // Allow browser-autocompletion on login form.
 // 0 - disabled, 1 - username and host only, 2 - username, host, password
 $rcmail_config['login_autocomplete'] = 0;
 
-// If users authentication is not case sensitive this must be enabled.
-// You can also use it to force conversion of logins to lower case.
-// After enabling it all user records need to be updated, e.g. with query:
-// UPDATE users SET username = LOWER(username);
-$rcmail_config['login_lc'] = false;
-
-// automatically create a new Roundcube user when log-in the first time.
-// a new user will be created once the IMAP login succeeds.
-// set to false if only registered users can use this service
-$rcmail_config['auto_create_user'] = true;
-
-// replace Roundcube logo with this image
-// specify an URL relative to the document root of this Roundcube installation
-$rcmail_config['skin_logo'] = null;
+// Forces conversion of logins to lower case.
+// 0 - disabled, 1 - only domain part, 2 - domain and local part.
+// If users authentication is case-insensitive this must be enabled.
+// Note: After enabling it all user records need to be updated, e.g. with query:
+//       UPDATE users SET username = LOWER(username);
+$rcmail_config['login_lc'] = 2;
 
 // Includes should be interpreted as PHP files
 $rcmail_config['skin_include_php'] = false;
 
+// display software version on login screen
+$rcmail_config['display_version'] = false;
+
 // Session lifetime in minutes
-// must be greater than 'keep_alive'/60
 $rcmail_config['session_lifetime'] = 10;
 
-// session domain: .example.org
+// Session domain: .example.org
 $rcmail_config['session_domain'] = '';
 
-// session name. Default: 'roundcube_sessid'
+// Session name. Default: 'roundcube_sessid'
 $rcmail_config['session_name'] = null;
+
+// Session authentication cookie name. Default: 'roundcube_sessauth'
+$rcmail_config['session_auth_name'] = null;
+
+// Session path. Defaults to PHP session.cookie_path setting.
+$rcmail_config['session_path'] = null;
 
 // Backend to use for session storage. Can either be 'db' (default) or 'memcache'
 // If set to memcache, a list of servers need to be specified in 'memcache_hosts'
@@ -235,8 +265,8 @@ $rcmail_config['session_name'] = null;
 $rcmail_config['session_storage'] = 'db';
 
 // Use these hosts for accessing memcached
-// Define any number of hosts in the form hostname:port
-$rcmail_config['memcache_hosts'] = null; // e.g. array( 'localhost:11211', '192.168.1.12:11211' );
+// Define any number of hosts in the form of hostname:port or unix:///path/to/socket.file
+$rcmail_config['memcache_hosts'] = null; // e.g. array( 'localhost:11211', '192.168.1.12:11211', 'unix:///var/tmp/memcached.sock' );
 
 // check client IP in session athorization
 $rcmail_config['ip_check'] = false;
@@ -258,10 +288,11 @@ $rcmail_config['des_key'] = 'cQro25fVv3ruWTNh0a6Sm1Rp';
 // Specify an array with 'host' => 'domain' values to support multiple hosts
 // Supported replacement variables:
 // %h - user's IMAP hostname
-// %n - http hostname ($_SERVER['SERVER_NAME'])
-// %d - domain (http hostname without the first part)
+// %n - hostname ($_SERVER['SERVER_NAME'])
+// %t - hostname without the first part
+// %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
 // %z - IMAP domain (IMAP hostname without the first part)
-// For example %n = mail.domain.tld, %d = domain.tld
+// For example %n = mail.domain.tld, %t = domain.tld
 $rcmail_config['username_domain'] = '';
 
 // This domain will be used to form e-mail addresses of new users
@@ -271,7 +302,7 @@ $rcmail_config['username_domain'] = '';
 // %n - http hostname ($_SERVER['SERVER_NAME'])
 // %d - domain (http hostname without the first part)
 // %z - IMAP domain (IMAP hostname without the first part)
-// For example %n = mail.domain.tld, %d = domain.tld
+// For example %n = mail.domain.tld, %t = domain.tld
 $rcmail_config['mail_domain'] = '';
 
 // Password charset.
@@ -283,11 +314,11 @@ $rcmail_config['password_charset'] = 'ISO-8859-1';
 $rcmail_config['sendmail_delay'] = 0;
 
 // Maximum number of recipients per message. Default: 0 (no limit)
-$rcmail_config['max_recipients'] = 0;
+$rcmail_config['max_recipients'] = 0; 
 
 // Maximum allowednumber of members of an address group. Default: 0 (no limit)
 // If 'max_recipients' is set this value should be less or equal
-$rcmail_config['max_group_members'] = 0;
+$rcmail_config['max_group_members'] = 0; 
 
 // add this user-agent to message headers when sending
 $rcmail_config['useragent'] = 'Roundcube Webmail/'.RCMAIL_VERSION;
@@ -327,14 +358,16 @@ $rcmail_config['line_length'] = 72;
 // send plaintext messages as format=flowed
 $rcmail_config['send_format_flowed'] = true;
 
-// don't allow these settings to be overriden by the user
-$rcmail_config['dont_override'] = array();
+// According to RFC2298, return receipt envelope sender address must be empty.
+// If this option is true, Roundcube will use user's identity as envelope sender for MDN responses.
+$rcmail_config['mdn_use_from'] = false;
 
 // Set identities access level:
 // 0 - many identities with possibility to edit all params
 // 1 - many identities with possibility to edit all params but not email address
 // 2 - one identity with possibility to edit all params
 // 3 - one identity with possibility to edit all params but not email address
+// 4 - one identity with possibility to edit only signature
 $rcmail_config['identities_level'] = 0;
 
 // Mimetypes supported by the browser.
@@ -342,8 +375,15 @@ $rcmail_config['identities_level'] = 0;
 // either a comma-separated list or an array: 'text/plain,text/html,text/xml,image/jpeg,image/gif,image/png,application/pdf'
 $rcmail_config['client_mimetypes'] = null;  # null == default
 
-// mime magic database
-$rcmail_config['mime_magic'] = '/usr/share/misc/magic';
+// Path to a local mime magic database file for PHPs finfo extension.
+// Set to null if the default path should be used.
+$rcmail_config['mime_magic'] = null;
+
+// Absolute path to a local mime.types mapping table file.
+// This is used to derive mime-types from the filename extension or vice versa.
+// Such a file is usually part of the apache webserver. If you don't find a file named mime.types on your system,
+// download it from http://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types
+$rcmail_config['mime_types'] = null;
 
 // path to imagemagick identify binary
 $rcmail_config['im_identify_path'] = null;
@@ -351,11 +391,20 @@ $rcmail_config['im_identify_path'] = null;
 // path to imagemagick convert binary
 $rcmail_config['im_convert_path'] = null;
 
+// Size of thumbnails from image attachments displayed below the message content.
+// Note: whether images are displayed at all depends on the 'inline_images' option.
+// Set to 0 to display images in full size.
+$rcmail_config['image_thumbnail_size'] = 240;
+
 // maximum size of uploaded contact photos in pixel
 $rcmail_config['contact_photo_size'] = 160;
 
 // Enable DNS checking for e-mail address validation
 $rcmail_config['email_dns_check'] = false;
+
+// Disables saving sent messages in Sent folder (like gmail) (Default: false)
+// Note: useful when SMTP server stores sent mail in user mailbox
+$rcmail_config['no_save_sent_messages'] = false;
 
 // ----------------------------------
 // PLUGINS
@@ -368,16 +417,16 @@ $rcmail_config['plugins'] = array('managesieve', 'carddav', 'twofactor_gauthenti
 // USER INTERFACE
 // ----------------------------------
 
-// default messages sort column. Use empty value for default server's sorting,
-// or 'arrival', 'date', 'subject', 'from', 'to', 'size', 'cc'
+// default messages sort column. Use empty value for default server's sorting, 
+// or 'arrival', 'date', 'subject', 'from', 'to', 'fromto', 'size', 'cc'
 $rcmail_config['message_sort_col'] = '';
 
 // default messages sort order
 $rcmail_config['message_sort_order'] = 'DESC';
 
 // These cols are shown in the message list. Available cols are:
-// subject, from, to, cc, replyto, date, size, status, flag, attachment, 'priority'
-$rcmail_config['list_cols'] = array('subject', 'status', 'from', 'date', 'size', 'flag', 'attachment');
+// subject, from, to, fromto, cc, replyto, date, size, status, flag, attachment, 'priority'
+$rcmail_config['list_cols'] = array('subject', 'status', 'fromto', 'date', 'size', 'flag', 'attachment');
 
 // the default locale setting (leave empty for auto-detection)
 // RFC1766 formatted language name like en_US, de_DE, de_CH, fr_FR, pt_BR
@@ -387,7 +436,8 @@ $rcmail_config['language'] = 'en_US';
 $rcmail_config['date_format'] = 'Y-m-d';
 
 // give this choice of date formats to the user to select from
-$rcmail_config['date_formats'] = array('Y-m-d', 'd-m-Y', 'Y/m/d', 'm/d/Y', 'd/m/Y', 'd.m.Y', 'j.n.Y');
+// Note: do not use ambiguous formats like m/d/Y
+$rcmail_config['date_formats'] = array('Y-m-d', 'Y/m/d', 'Y.m.d', 'd-m-Y', 'd/m/Y', 'd.m.Y', 'j.n.Y');
 
 // use this format for time display (date or strftime format)
 $rcmail_config['time_format'] = 'H:i';
@@ -423,16 +473,15 @@ $rcmail_config['trash_mbox'] = 'Trash';
 // display these folders separately in the mailbox list.
 // these folders will also be displayed with localized names
 // NOTE: Use folder names with namespace prefix (INBOX. on Courier-IMAP)
-$rcmail_config['default_imap_folders'] = array('INBOX', 'Drafts', 'Sent', 'Junk', 'Trash');
+$rcmail_config['default_folders'] = array('INBOX', 'Drafts', 'Sent', 'Junk', 'Trash');
 
 // automatically create the above listed default folders on first login
-// $rcmail_config['create_default_folders'] = false;
 $rcmail_config['create_default_folders'] = true;
 
 // protect the default folders from renames, deletes, and subscription changes
 $rcmail_config['protect_default_folders'] = true;
 
-// if in your system 0 quota means no limit set this option to true
+// if in your system 0 quota means no limit set this option to true 
 $rcmail_config['quota_zero_as_unlimited'] = false;
 
 // Make use of the built-in spell checker. It is based on GoogieSpell.
@@ -474,9 +523,8 @@ $rcmail_config['recipients_separator'] = ',';
 // don't let users set pagesize to more than this value if set
 $rcmail_config['max_pagesize'] = 200;
 
-// Minimal value of user's 'keep_alive' setting (in seconds)
-// Must be less than 'session_lifetime'
-$rcmail_config['min_keep_alive'] = 60;
+// Minimal value of user's 'refresh_interval' setting (in seconds)
+$rcmail_config['min_refresh_interval'] = 60;
 
 // Enables files upload indicator. Requires APC installed and enabled apc.rfc1867 option.
 // By default refresh time is set to 1 second. You can set this value to true
@@ -493,10 +541,12 @@ $rcmail_config['undo_timeout'] = 0;
 // ----------------------------------
 
 // This indicates which type of address book to use. Possible choises:
-// 'sql' (default) and 'ldap'.
+// 'sql' (default), 'ldap' and ''.
 // If set to 'ldap' then it will look at using the first writable LDAP
 // address book as the primary address book and it will not display the
 // SQL address book in the 'Address Book' view.
+// If set to '' then no address book will be displayed or only the
+// addressbook which is created by a plugin (like CardDAV).
 $rcmail_config['address_book_type'] = 'sql';
 
 // In order to enable public ldap search, configure an array like the Verisign
@@ -504,7 +554,7 @@ $rcmail_config['address_book_type'] = 'sql';
 // Array key must contain only safe characters, ie. a-zA-Z0-9_
 $rcmail_config['ldap_public'] = array();
 
-// If you are going to use LDAP for individual address books, you will need to
+// If you are going to use LDAP for individual address books, you will need to 
 // set 'user_specific' to true and use the variables to generate the appropriate DNs to access it.
 //
 // The recommended directory structure for LDAP is to store all the address book entries
@@ -524,14 +574,16 @@ $rcmail_config['ldap_public']['Verisign'] = array(
 'name'          => 'Verisign.com',
 // Replacement variables supported in host names:
 // %h - user's IMAP hostname
-// %n - http hostname ($_SERVER['SERVER_NAME'])
-// %d - domain (http hostname without the first part)
+// %n - hostname ($_SERVER['SERVER_NAME'])
+// %t - hostname without the first part
+// %d - domain (http hostname $_SERVER['HTTP_HOST'] without the first part)
 // %z - IMAP domain (IMAP hostname without the first part)
-// For example %n = mail.domain.tld, %d = domain.tld
+// For example %n = mail.domain.tld, %t = domain.tld
 'hosts'         => array('directory.verisign.com'),
 'port'          => 389,
 'use_tls'	      => false,
 'ldap_version'  => 3,       // using LDAPv3
+'network_timeout' => 10,    // The timeout (in seconds) for connect + bind arrempts. This is only supported in PHP >= 5.3.0 with OpenLDAP 2.x
 'user_specific' => false,   // If true the base_dn, bind_dn and bind_pass default to the user's IMAP login.
 // %fu - The full username provided, assumes the username is an email
 //       address, uses the username_domain value if not an email address.
@@ -571,26 +623,47 @@ $rcmail_config['ldap_public']['Verisign'] = array(
 // The RDN field that is used for new entries, this field needs
 // to be one of the search_fields, the base of base_dn is appended
 // to the RDN to insert into the LDAP directory.
-'LDAP_rdn'       => 'mail',
+'LDAP_rdn'       => 'cn',
 // The required fields needed to build a new contact as required by
 // the object classes (can include additional fields not required by the object classes).
 'required_fields' => array('cn', 'sn', 'mail'),
 'search_fields'   => array('mail', 'cn'),  // fields to search in
 // mapping of contact fields to directory attributes
+//   for every attribute one can specify the number of values (limit) allowed.
+//   default is 1, a wildcard * means unlimited
 'fieldmap' => array(
-// Roundcube  => LDAP
+// Roundcube  => LDAP:limit
 'name'        => 'cn',
 'surname'     => 'sn',
 'firstname'   => 'givenName',
-'email'       => 'mail',
+'jobtitle'    => 'title',
+'email'       => 'mail:*',
 'phone:home'  => 'homePhone',
 'phone:work'  => 'telephoneNumber',
 'phone:mobile' => 'mobile',
+'phone:pager' => 'pager',
 'street'      => 'street',
 'zipcode'     => 'postalCode',
+'region'      => 'st',
 'locality'    => 'l',
-'country'     => 'c',
+// if you country is a complex object, you need to configure 'sub_fields' below
+'country'      => 'c',
 'organization' => 'o',
+'department'   => 'ou',
+'jobtitle'     => 'title',
+'notes'        => 'description',
+// these currently don't work:
+// 'phone:workfax' => 'facsimileTelephoneNumber',
+// 'photo'         => 'jpegPhoto',
+// 'manager'       => 'manager',
+// 'assistant'     => 'secretary',
+),
+// Map of contact sub-objects (attribute name => objectClass(es)), e.g. 'c' => 'country'
+'sub_fields' => array(),
+// Generate values for the following LDAP attributes automatically when creating a new record
+'autovalues' => array(
+// 'uid'  => 'md5(microtime())',               // You may specify PHP code snippets which are then eval'ed 
+// 'mail' => '{givenname}.{sn}@mydomain.com',  // or composite strings with placeholders for existing attributes
 ),
 'sort'          => 'cn',    // The field to sort the listing by.
 'scope'         => 'sub',   // search mode: sub|base|list
@@ -605,7 +678,7 @@ $rcmail_config['ldap_public']['Verisign'] = array(
 // definition for contact groups (uncomment if no groups are supported)
 // for the groups base_dn, the user replacements %fu, %u, $d and %dc work as for base_dn (see above)
 // if the groups base_dn is empty, the contact base_dn is used for the groups as well
-// -> in this case, assure that groups and contacts are separated due to the concernig filters!
+// -> in this case, assure that groups and contacts are separated due to the concernig filters! 
 'groups'        => array(
 'base_dn'     => '',
 'scope'       => 'sub',   // search mode: sub|base|list
@@ -654,10 +727,13 @@ $rcmail_config['addressbook_search_mode'] = 0;
 $rcmail_config['default_charset'] = 'UTF-8';
 
 // skin name: folder from skins/
-$rcmail_config['skin'] = 'default';
+$rcmail_config['skin'] = 'larry';
 
-// show up to X items in list view
-$rcmail_config['pagesize'] = 40;
+// show up to X items in messages list view
+$rcmail_config['mail_pagesize'] = 50;
+
+// show up to X items in contacts list view
+$rcmail_config['addressbook_pagesize'] = 50;
 
 // sort contacts by this col (preferably either one of name, firstname, surname)
 $rcmail_config['addressbook_sort_col'] = 'surname';
@@ -670,10 +746,9 @@ $rcmail_config['addressbook_sort_col'] = 'surname';
 $rcmail_config['addressbook_name_listing'] = 0;
 
 // use this timezone to display date/time
+// valid timezone identifers are listed here: php.net/manual/en/timezones.php
+// 'auto' will use the browser's timezone settings
 $rcmail_config['timezone'] = 'auto';
-
-// is daylight saving On? Default: (bool)date('I');
-$rcmail_config['dst_active'] = null;
 
 // prefer displaying HTML messages
 $rcmail_config['prefer_html'] = true;
@@ -684,8 +759,14 @@ $rcmail_config['prefer_html'] = true;
 // 2 - Always show inline images
 $rcmail_config['show_images'] = 0;
 
+// open messages in new window
+$rcmail_config['message_extwin'] = false;
+
+// open message compose form in new window
+$rcmail_config['compose_extwin'] = false;
+
 // compose html formatted messages by default
-// 0 - never, 1 - always, 2 - on reply to HTML message only
+// 0 - never, 1 - always, 2 - on reply to HTML message, 3 - on forward or reply to HTML message
 $rcmail_config['htmleditor'] = 0;
 
 // show pretty dates as standard
@@ -707,7 +788,7 @@ $rcmail_config['logout_purge'] = false;
 // Compact INBOX on logout
 $rcmail_config['logout_expunge'] = false;
 
-// Display attached images below the message body
+// Display attached images below the message body 
 $rcmail_config['inline_images'] = true;
 
 // Encoding of long/non-ascii attachment names:
@@ -728,23 +809,27 @@ $rcmail_config['read_when_deleted'] = true;
 // Use 'Purge' to remove messages marked as deleted
 $rcmail_config['flag_for_deletion'] = false;
 
-// Default interval for keep-alive/check-recent requests (in seconds)
-// Must be greater than or equal to 'min_keep_alive' and less than 'session_lifetime'
-$rcmail_config['keep_alive'] = 60;
+// Default interval for auto-refresh requests (in seconds)
+// These are requests for system state updates e.g. checking for new messages, etc.
+// Setting it to 0 disables the feature.
+$rcmail_config['refresh_interval'] = 60;
 
 // If true all folders will be checked for recent messages
 $rcmail_config['check_all_folders'] = false;
 
 // If true, after message delete/move, the next message will be displayed
-$rcmail_config['display_next'] = false;
+$rcmail_config['display_next'] = true;
 
-// 0 - Do not expand threads
-// 1 - Expand all threads automatically
-// 2 - Expand only threads with unread messages
+// 0 - Do not expand threads 
+// 1 - Expand all threads automatically 
+// 2 - Expand only threads with unread messages 
 $rcmail_config['autoexpand_threads'] = 0;
 
-// When replying place cursor above original message (top posting)
-$rcmail_config['top_posting'] = false;
+// When replying:
+// -1 - don't cite the original message
+// 0  - place cursor below the original message
+// 1  - place cursor above original message (top posting)
+$rcmail_config['reply_mode'] = 0;
 
 // When replying strip original signature from message
 $rcmail_config['strip_existing_sig'] = true;
@@ -756,16 +841,13 @@ $rcmail_config['strip_existing_sig'] = true;
 // 3 - Forwards and Replies only
 $rcmail_config['show_sig'] = 1;
 
-// When replying or forwarding place sender's signature above existing message
-$rcmail_config['sig_above'] = false;
-
 // Use MIME encoding (quoted-printable) for 8bit characters in message body
 $rcmail_config['force_7bit'] = false;
 
 // Defaults of the search field configuration.
 // The array can contain a per-folder list of header fields which should be considered when searching
 // The entry with key '*' stands for all folders which do not have a specific list set.
-// Please note that folder names should to be in sync with $rcmail_config['default_imap_folders']
+// Please note that folder names should to be in sync with $rcmail_config['default_folders']
 $rcmail_config['search_mods'] = null;  // Example: array('*' => array('subject'=>1, 'from'=>1), 'Sent' => array('subject'=>1, 'to'=>1));
 
 // Defaults of the addressbook search field configuration.
@@ -777,6 +859,9 @@ $rcmail_config['addressbook_search_mods'] = null;  // Example: array('name'=>1, 
 // when user is over quota and Trash is included in the quota.
 $rcmail_config['delete_always'] = false;
 
+// Directly delete messages in Junk instead of moving to Trash
+$rcmail_config['delete_junk'] = false;
+
 // Behavior if a received message requests a message delivery notification (read receipt)
 // 0 = ask the user, 1 = send automatically, 2 = ignore (never send or ask)
 // 3 = send automatically if sender is in addressbook, otherwise ask the user
@@ -787,6 +872,7 @@ $rcmail_config['mdn_requests'] = 0;
 $rcmail_config['mdn_default'] = 0;
 
 // Delivery Status Notification checkbox default state
+// Note: This can be used only if smtp_server is non-empty
 $rcmail_config['dsn_default'] = 0;
 
 // Place replies in the folder of the message being replied to
@@ -805,5 +891,10 @@ $rcmail_config['spellcheck_before_send'] = false;
 
 // Skip alternative email addresses in autocompletion (show one address per contact)
 $rcmail_config['autocomplete_single'] = false;
+
+// Default font for composed HTML message.
+// Supported values: Andale Mono, Arial, Arial Black, Book Antiqua, Courier New,
+// Georgia, Helvetica, Impact, Tahoma, Terminal, Times New Roman, Trebuchet MS, Verdana
+$rcmail_config['default_font'] = 'Verdana';
 
 // end of config file

--- a/roles/webmail/tasks/roundcube.yml
+++ b/roles/webmail/tasks/roundcube.yml
@@ -13,13 +13,13 @@
   - roundcube-plugins
   when: ansible_distribution_release == 'wheezy'
 
- - name: Install Roundcube on Ubuntu 14.04 LTS
-   apt: pkg={{ item }} state=latest
-   with_items:
-   - roundcube
-   - roundcube-pgsql
-   - roundcube-plugins
-   when: ansible_distribution_release == 'trusty'
+- name: Install Roundcube on Ubuntu 14.04 LTS
+  apt: pkg={{ item }} state=latest
+  with_items:
+  - roundcube
+  - roundcube-pgsql
+  - roundcube-plugins
+  when: ansible_distribution_release == 'trusty'
 
 - name: Configure Roundcube database
   template: src={{ item.src }} dest={{ item.dest }} group={{ item.group }} mode={{ item.mode }} owner=root force=yes

--- a/roles/webmail/tasks/roundcube.yml
+++ b/roles/webmail/tasks/roundcube.yml
@@ -1,5 +1,11 @@
+- name: Add backports for Roundcube
+  lineinfile: dest=/etc/apt/sources.list line="deb http://http.debian.net/debian wheezy-backports main"
+
+- name: Update apt cache for backports
+  apt: update_cache=yes
+
 - name: Install Roundcube
-  apt: pkg={{ item }} state=latest
+  apt: pkg={{ item }} state=latest default_release=wheezy-backports
   with_items:
     - roundcube
     - roundcube-pgsql


### PR DESCRIPTION
Debian 7.7 uses Roundcube 0.7.x, which is pretty old.  There appear to be lots of fixes and improvements in the 0.9.x and 1.0.x series.  Suggest moving to 0.9.x using the package in wheezy backports.

Changes:
- Added backports to apt configuration.
- Updated roundcube task to use the roundcube backport.
- Updated roundcube's main.inc.php configuration file to use the one included in the backport distribution.  Migrated configuration parameters from the existing configuration file except in cases where it looked like the Roundcube team was changing defaults that were not touched by Sovereign's configuration.  I may have gotten some wrong; needs review by a Sovereign maintainer.

This was tested in the development environment and has been deployed on my own server.