### PR TITLE
Fix monit monitoring for apache

### DIFF
--- a/roles/monitoring/files/etc_apache2_sites-available_00-status.conf
+++ b/roles/monitoring/files/etc_apache2_sites-available_00-status.conf
@@ -1,0 +1,10 @@
+# This needs to be the first configured virtualhost on port 80 so that
+# requests to http://localhost hit this rather than any other vhost
+<VirtualHost *:80>
+  <Location />
+    SetHandler server-status
+    Order deny,allow
+    Deny from all
+    Allow from 127.0.0.1
+  </Location>
+</VirtualHost>

--- a/roles/monitoring/tasks/monit.yml
+++ b/roles/monitoring/tasks/monit.yml
@@ -1,3 +1,10 @@
+- name: Add monitoring vhost to apache
+  copy: src=etc_apache2_sites-available_00-status.conf dest=/etc/apache2/sites-available/00-status.conf
+
+- name: Enable the status vhost
+  command: a2ensite 00-status.conf creates=/etc/apache2/sites-enabled/00-status.conf
+  notify: restart apache
+
 - name: Install monit
   apt: pkg=monit state=installed
 


### PR DESCRIPTION
Add a status vhost to apache, so that monit's http monitoring will work.
It doesn't particularly matter to the monit check what this vhost does
as long as it returns 200, but I thought it would be nice to use
apache's builtin status functionality.  Ideas cribbed from [1].  It
might also be possible to use monit's apache-status functionality to
alert on more sophisticated criteria, but this will do for now.

Open question: does collectd support apache-status? Might it also be
interested in this vhost?

Fixes #299.

[1] http://mmonit.com/wiki/Monit/MonitorApacheStatus