### PR TITLE
Postfix: Disable SSLv3 for TLS connections

### DIFF
--- a/roles/mailserver/templates/etc_postfix_main.cf.j2
+++ b/roles/mailserver/templates/etc_postfix_main.cf.j2
@@ -36,6 +36,8 @@ unverified_recipient_reject_code = 554
 unverified_sender_reject_code = 554
 
 # TLS parameters
+smtpd_tls_mandatory_protocols=!SSLv2,!SSLv3
+smtp_tls_mandatory_protocols=!SSLv2,!SSLv3
 smtpd_tls_cert_file=/etc/ssl/certs/wildcard_combined.pem
 smtpd_tls_key_file=/etc/ssl/private/wildcard_private.key
 smtpd_use_tls=yes

--- a/roles/mailserver/templates/etc_postfix_main.cf.j2
+++ b/roles/mailserver/templates/etc_postfix_main.cf.j2
@@ -38,6 +38,8 @@ unverified_sender_reject_code = 554
 # TLS parameters
 smtpd_tls_mandatory_protocols=!SSLv2,!SSLv3
 smtp_tls_mandatory_protocols=!SSLv2,!SSLv3
+smtp_tls_protocols = !SSLv2,!SSLv3
+smtpd_tls_protocols = !SSLv2,!SSLv3
 smtpd_tls_cert_file=/etc/ssl/certs/wildcard_combined.pem
 smtpd_tls_key_file=/etc/ssl/private/wildcard_private.key
 smtpd_use_tls=yes


### PR DESCRIPTION
Postfix: Disable SSLv2 and SSLv3 for 'mandatory SSL' mode connections to completely mitigate the POODLE issue.