### PR TITLE
Install php5-gd dependency for selfoss.

### DIFF
--- a/roles/news/tasks/selfoss.yml
+++ b/roles/news/tasks/selfoss.yml
@@ -6,6 +6,13 @@
 - name: Set selfoss permissions
   action: file owner=www-data group=www-data path=/var/www/selfoss recurse=yes state=directory
 
+- name: Install selfoss dependencies
+  apt: pkg={{ item }} state=present
+  with_items:
+    - php5
+    - php5-pgsql
+    - php5-gd
+
 - name: Create database user for selfoss
   postgresql_user: login_host=localhost login_user={{ db_admin_username }} login_password="{{ db_admin_password }}" name={{ selfoss_db_username }} password="{{ selfoss_db_password }}" state=present
 


### PR DESCRIPTION
When trying to refresh some selfoss rss feeds, I get an error related to processing images:

```
Internal Server Error
Fatal error: Call to undefined function imagecreatefromstring()
```

Installing the php5-gd dependency fixes this (on Ubuntu, at least). I went ahead and made the selfoss php dependencies explicit, too.