### PR TITLE
Enable UFW only after setting firewall rules

### DIFF
--- a/roles/common/tasks/ufw.yml
+++ b/roles/common/tasks/ufw.yml
@@ -5,8 +5,8 @@
 - name: Install ufw
   apt: pkg=ufw state=present
 
-- name: Deny everything and enable UFW
-  ufw: state=enabled policy=deny
+- name: Deny everything
+  ufw: policy=deny
 
 - name: Set firewall rule for DNS
   ufw: rule=allow port=domain
@@ -20,6 +20,9 @@
     - http
     - https
     - ssh
+
+- name: Enable UFW
+  ufw: state=enabled
 
 - name: Check config of ufw
   command: cat /etc/ufw/ufw.conf


### PR DESCRIPTION
On fresh installs of Debian 7.6, the current order of steps will lock you
out of SSH. This change will enable UFW only after creating firewall rules for http, https, ssh,
and DNS. Fix comes from @Debugreality in issue #303:
