### PR TITLE
Bump checkrbl version to stop using ahbl

### DIFF
--- a/roles/mailserver/tasks/checkrbl.yml
+++ b/roles/mailserver/tasks/checkrbl.yml
@@ -1,5 +1,5 @@
 - name: Download check-rbl
-  get_url: url=https://raw.github.com/lukecyca/check-rbl/2af83dd9c4/check-rbl.pl dest=/opt/check-rbl.pl
+  get_url: url=https://raw.github.com/lukecyca/check-rbl/38006028bc1865e9c/check-rbl.pl dest=/opt/check-rbl.pl sha256sum=59a8e15ee702e8c056426ebdd155fdd7a651716f40c58b7a4fef2a1c312f07da
 
 - name: Install nightly check-rbl cronjob
   cron: name="check-rbl" hour="2" minute="0" job="perl /opt/check-rbl.pl -i {{ ansible_default_ipv4.address }}"


### PR DESCRIPTION
ahbl is no longer being maintained and has been configured to return a
positive value for every host.  This means I get a cron warning every
day reporting that my mailserver is in ircbl.ahbl.org and
dnsbl.ahbl.org.

lukecyca/check-rbl#1 has removed ahbl from the blacklists that it
checks.  This just pulls in that change.

Unfortunately, ansible's get_url won't update files which have been
downloaded already unless you set force=yes, which will cause ansible to
pull down the file from github on every single run, which isn't really
acceptable.  I have filed ansible/ansible-modules-core#625 to ask that
get_url redownload if and only if the sha256sum differs.  In the
meantime, you have to manually delete /opt/check-rbl.pl before rerunning
ansible to pull in the update.  However, at least this will work fine
for new installs.

Related to #338 (though I don't know if it truly fixes it).