### PR TITLE
Automatically set sudoers using /etc/sudoers.d/

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -123,10 +123,6 @@ nano /home/deploy/.ssh/authorized_keys
 chmod 400 /home/deploy/.ssh/authorized_keys
 chown deploy:deploy /home/deploy -R
 
-This account should be set up for passwordless sudo. Use @visudo@ and add this line:
-
-bc. deploy  ALL=(ALL) NOPASSWD: ALL
-
 h3. 4. Configure your installation
 
 Modify the settings in @vars/user.yml@ to your liking. If you want to see how they're used in context, just search for the corresponding string.

--- a/roles/common/tasks/users.yml
+++ b/roles/common/tasks/users.yml
@@ -1,2 +1,5 @@
 - name: Create main user account
   user: name={{ main_user_name }} state=present shell={{ main_user_shell }} groups=sudo,fuse
+
+- name: Give main user account sudo power
+  template: src=roles/common/templates/sudoers.j2 dest=/etc/sudoers.d/sudoers owner=root group=root mode=0440 validate='visudo -cf %s'

--- a/roles/common/templates/sudoers.j2
+++ b/roles/common/templates/sudoers.j2
@@ -1,0 +1,1 @@
+{{ main_user_name }} ALL=(ALL) NOPASSWD: ALL


### PR DESCRIPTION
This commit makes it so that sudo privileges are automatically set for the main user account via /etc/sudoers.d/. I have tested this on Debian Wheezy with Vagrant, and it appears to work as expected (running e.g. `"sudo vim /etc/sudoers"` works without password, as does `"sudo su -"`). This should make obsolete pull request  #309 (also from me, will close). I have also removed from the README the lines about adding this functionality via `visudo`, as it is no longer needed.

Please note I am not an expert on this, so it would be good to have someone look this over/test it out and ensure that I haven't missed something. If I did this in a non-ideal way, I'd like to learn how to do it better next time. This is my first real OSS commit via git/github, so accept with caution.