### PR TITLE
Create main user without "fuse" group, instead add it later

### DIFF
--- a/roles/common/tasks/encfs.yml
+++ b/roles/common/tasks/encfs.yml
@@ -14,6 +14,9 @@
 - name: Add mail user to fuse group
   user: name=mail append=yes groups=fuse
 
+- name: Add main user to fuse group
+  user: name={{ main_user_name }} append=yes groups=fuse
+
 # Check if the /encrypted directory is empty
 - name: Check for existing encfs
   shell: ls /encrypted/*

--- a/roles/common/tasks/encfs.yml
+++ b/roles/common/tasks/encfs.yml
@@ -8,9 +8,6 @@
 - name: Create encrypted directory
   file: state=directory path=/encrypted
 
-- name: Create decrypted directory
-  file: state=directory path=/decrypted
-
 - name: Add mail user to fuse group
   user: name=mail append=yes groups=fuse
 

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -57,6 +57,12 @@
   notify: restart apache
   when: ansible_distribution_release == 'trusty'
 
+- name: Create decrypted directory (even if encfs isn't used)
+  file: state=directory path=/decrypted
+
+- name: Set decrypted directory permissions
+  file: state=directory path=/decrypted group=mail mode=775
+
 - include: encfs.yml tags=encfs
 - include: users.yml tags=users
 - include: ssl.yml tags=ssl

--- a/roles/common/tasks/users.yml
+++ b/roles/common/tasks/users.yml
@@ -1,2 +1,2 @@
 - name: Create main user account
-  user: name={{ main_user_name }} state=present shell={{ main_user_shell }} groups=sudo,fuse
+  user: name={{ main_user_name }} state=present shell={{ main_user_shell }} groups=sudo


### PR DESCRIPTION
Add group "fuse" to main user only as part of the "encfs" tag. This allows the user to make encfs optional.

Also, always create the /decrypted directory, even if encfs tag is skipped.

Helps with issue #120.