### PR TITLE
Remove redundant step for creating a deploy user in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,8 @@ For goodness sake, change the root password:
 
 Create a user account for Ansible to do its thing through:
 
-    useradd deploy
+    useradd -m deploy
     passwd deploy
-    mkdir /home/deploy
 
 Authorize your ssh key if you want passwordless ssh login (optional):
 


### PR DESCRIPTION
A minor change really