### PR TITLE
Add molly-guard and unattended-upgrades as common pkgs

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -28,6 +28,8 @@
     - screen
     - sudo
     - update-notifier-common
+    - unattended-upgrades
+    - molly-guard
     - vim
     - zsh
 


### PR DESCRIPTION
Hi,
I'm using this useful packages, maybe it can be integrated in sovereign too.
Cheers